### PR TITLE
Disallow all but the most current API/Lore documentation from being indexed by search engines

### DIFF
--- a/vhosts/twistedmatrix.com/robots.txt
+++ b/vhosts/twistedmatrix.com/robots.txt
@@ -13,6 +13,8 @@ Disallow: /trac/newticket
 Disallow: /trac/search
 Disallow: /trac/diff
 Disallow: /projects/
+Allow: /documents/current/
+Disallow: /documents/
 
 User-agent: AhrefsBot
 Disallow: /


### PR DESCRIPTION
This change would disallow Google/Bing/et al from indexing old versions of the documentation, and just 'current'. The upside of this is that googling for "twisted api documentation" will then bring up the most recent always (and not 13.1.0 like it does currently). The downside to this is that it makes searching for older versions of the API documentation much harder (eg. "twisted 8.2 api documentation" wouldn't come up with anything).
