### PR TITLE
the first Wigu comic is now at a different URL

### DIFF
--- a/maintenance-site/index.html
+++ b/maintenance-site/index.html
@@ -3,7 +3,7 @@
     <p>Temporarily down for maintenance.</p>
     <p>Please try back in a few minutes.</p>
     <p>
-      <a href="http://jjrowland.com/wigu/20020107.html">
+      <a href="http://www.wigucomics.com/adventures/index.php?comic=1">
         You may enjoy this while you wait.
       </a>
     </p>


### PR DESCRIPTION
The maintenance page points at an outdated Wigu comic URL which now 404s. This updates to the new URL of the first comic.
